### PR TITLE
Imposing the type specification on CohortCalculator

### DIFF
--- a/src/main/scala/uk/gov/hmrc/abtest/CohortCalculator.scala
+++ b/src/main/scala/uk/gov/hmrc/abtest/CohortCalculator.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.abtest
 
-trait CohortCalculator[C <: Cohort] {
+trait CohortCalculator[K, C <: Cohort] {
   def cohorts: Cohorts[C]
 
-  def calculate[T](id: T): C = cohorts.values.drop(math.abs(id.hashCode) % cohorts.values.size).head
+  def calculate(id: K): C = cohorts.values.drop(math.abs(id.hashCode) % cohorts.values.size).head
 }

--- a/src/test/scala/uk/gov/hmrc/abtest/CohortSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/abtest/CohortSpec.scala
@@ -26,8 +26,6 @@ class CohortSpec extends WordSpec with Matchers {
       val name = "cohort"
     }
 
-    object RandomObject
-
     val anId = 1234
     val anotherId = anId + 1
     val stringId = "1234"
@@ -61,9 +59,10 @@ class CohortSpec extends WordSpec with Matchers {
       calculate(stringId).id should be (1)
     }
 
-    "return matching typed cohort using the RandomObject key type for calculation" in new CohortCalculator[RandomObject.type, AnotherCohort.type] {
+    "fail compilation if key type used for cohort calculation is different from the one specified during creation" in new CohortCalculator[String, AnotherCohort.type] {
       val cohorts = Cohorts(AnotherCohort)
-      calculate(RandomObject) should be (AnotherCohort)
+      val anIntId = 5;
+      "calculate(anIntId)" shouldNot compile
     }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/abtest/CohortSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/abtest/CohortSpec.scala
@@ -26,6 +26,8 @@ class CohortSpec extends WordSpec with Matchers {
       val name = "cohort"
     }
 
+    object RandomObject
+
     val anId = 1234
     val anotherId = anId + 1
     val stringId = "1234"
@@ -37,26 +39,31 @@ class CohortSpec extends WordSpec with Matchers {
       def name: String = "anotherCohort"
     }
 
-     "return only available cohort when only one specified" in new CohortCalculator[Cohort] {
+     "return only available cohort when only one specified" in new CohortCalculator[Int, Cohort] {
        val cohorts = Cohorts(cohort)
        calculate(anId) should be (cohort)
      }
 
-    "return matching cohort for given id" in new CohortCalculator[Cohort] {
+    "return matching cohort for given id" in new CohortCalculator[Int, Cohort] {
       val cohorts = Cohorts(cohort, anotherCohort)
       val firstCohort = calculate(anId)
       val secondCohort = calculate(anotherId)
       cohorts.values should contain allOf(firstCohort, secondCohort)
     }
 
-    "return matching cohort for an id of any type" in new CohortCalculator[Cohort] {
+    "return matching cohort for an id of any type" in new CohortCalculator[String, Cohort] {
       val cohorts = Cohorts(cohort)
       calculate(stringId) should be (cohort)
     }
 
-    "return matching typed cohort" in new CohortCalculator[AnotherCohort.type] {
+    "return matching typed cohort" in new CohortCalculator[String, AnotherCohort.type] {
       val cohorts = Cohorts(AnotherCohort)
       calculate(stringId).id should be (1)
+    }
+
+    "return matching typed cohort using the RandomObject key type for calculation" in new CohortCalculator[RandomObject.type, AnotherCohort.type] {
+      val cohorts = Cohorts(AnotherCohort)
+      calculate(RandomObject) should be (AnotherCohort)
     }
   }
 }


### PR DESCRIPTION
Currently, CohortCalculator uses any type of key to perform calculation at run time.
However, this can lead to inconsistent results if different types of keys are used for calculation on same set of cohorts.

Hence, imposing the type of key for CohortCalculator at creation itself, so that it returns the same cohort each time, from a given set of cohorts.